### PR TITLE
Fix record counts in XSL

### DIFF
--- a/views/public/xsl/oai-pmh-repository.xsl
+++ b/views/public/xsl/oai-pmh-repository.xsl
@@ -839,9 +839,9 @@ No support (may depend on server):
             </xsl:when>
             <!-- Not last page. -->
             <xsl:when test="normalize-space($path/../oai:resumptionToken/text()) != ''">
-                <xsl:value-of select="($cursor * $count) + 1" />
+                <xsl:value-of select="$cursor + 1" />
                 <xsl:text>-</xsl:text>
-                <xsl:value-of select="($cursor + 1) * $count" />
+                <xsl:value-of select="$cursor + $count" />
             </xsl:when>
             <!-- Last page. -->
             <xsl:when test="$total">
@@ -873,7 +873,7 @@ No support (may depend on server):
             </xsl:when>
             <!-- Not last page. -->
             <xsl:when test="normalize-space($path/../oai:resumptionToken/text()) != ''">
-                <xsl:value-of select="$cursor * $count" />
+                <xsl:value-of select="$cursor" />
             </xsl:when>
             <!-- Last page. -->
             <xsl:when test="$total">


### PR DESCRIPTION
Cursor doesn't say how many pages of results have been previously
delivered, rather how many actual results. So multiplying by count is
not correct; simply use the cursor value, or cursor + 1, etc.